### PR TITLE
User admin page cleanup

### DIFF
--- a/birdspotter/birdspotter/accounts/admin.py
+++ b/birdspotter/birdspotter/accounts/admin.py
@@ -15,5 +15,6 @@ class UserModelAdmin(UserAdmin):
     )
     readonly_fields = ('last_login', 'date_joined')
 
+
 admin.site.register(User, UserModelAdmin)
 admin.site.register(GroupRequest)

--- a/birdspotter/birdspotter/accounts/admin.py
+++ b/birdspotter/birdspotter/accounts/admin.py
@@ -4,9 +4,16 @@ from django.contrib.auth.admin import UserAdmin
 from birdspotter.accounts.models import User, GroupRequest
 
 
-class UserModelAdmin(UserAdmin):
-    pass
 
+class UserModelAdmin(UserAdmin):
+    fieldsets = (
+        (None, {'fields': ('username', 'password')}),
+        (('Personal info'), {'fields': ('first_name', 'last_name', 'email')}),
+        (('Permissions'), {'fields': ('is_active', 'is_staff', 'is_superuser',
+                                       'groups',)}),
+        (('Important dates'), {'fields': ('last_login', 'date_joined')}),
+    )
+    readonly_fields = ('last_login', 'date_joined')
 
 admin.site.register(User, UserModelAdmin)
 admin.site.register(GroupRequest)


### PR DESCRIPTION
Remove permissions from user admin page as they are not actually used for anything, make last_login & date_joined view only