### PR TITLE
Migrate Dockerhub to Org Repo

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,7 @@ steps:
   commands:
     - cd /app/birdspotter
     - python manage.py makemigrations && python manage.py migrate
+    - python manage.py collectstatic
     - coverage run --source='.' manage.py test
     - coverage report
     - coverage xml
@@ -22,6 +23,7 @@ steps:
   image: birdspotter/birdspotter:dev
   commands:
     - cd /app/birdspotter
+    - export PROD_MODE=true
     - python3 manage.py check --deploy 2>&1
 - name: publish-dev-image
   depends_on: [unit-test, linter-tests, deployment-test]
@@ -71,6 +73,6 @@ trigger:
     - tag
 ---
 kind: signature
-hmac: da0c25f1219c23076d69a2dcd9a8d4a9eacf8d0dbab852f279bc1756982b36d9
+hmac: 3a5262b923b1987064405826914d7c54ed20ae48221d8f71bb55b60715bf6b3f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ workspace:
   base: /app
 steps:
 - name: unit-test
-  image: devinchristianson/birdspotter:dev-deps
+  image: birdspotter/birdspotter:dev-deps
   commands:
     - cd /app/birdspotter
     - python manage.py makemigrations && python manage.py migrate
@@ -14,12 +14,12 @@ steps:
     - coverage report
     - coverage xml
 - name: linter-tests
-  image: devinchristianson/birdspotter:dev-deps
+  image: birdspotter/birdspotter:dev-deps
   commands:
     - cd /app/birdspotter
     - prospector
 - name: deployment-test
-  image: devinchristianson/birdspotter:dev
+  image: birdspotter/birdspotter:dev
   commands:
     - cd /app/birdspotter
     - python3 manage.py check --deploy 2>&1
@@ -32,7 +32,7 @@ steps:
       - push
   image: plugins/docker
   settings:
-    repo: devinchristianson/birdspotter
+    repo: birdspotter/birdspotter
     username: 
       from_secret: dockerhub_username
     password: 
@@ -51,7 +51,7 @@ steps:
       - tag
   image: plugins/docker
   settings:
-    repo: devinchristianson/birdspotter
+    repo: birdspotter/birdspotter
     username: 
       from_secret: dockerhub_username
     password: 
@@ -71,6 +71,6 @@ trigger:
     - tag
 ---
 kind: signature
-hmac: c3570d7065ffa5d7f8510637b5348902ad22823493e5326fe35b7bfde074b3a6
+hmac: da0c25f1219c23076d69a2dcd9a8d4a9eacf8d0dbab852f279bc1756982b36d9
 
 ...

--- a/birdspotter/birdspotter/settings.py
+++ b/birdspotter/birdspotter/settings.py
@@ -31,7 +31,7 @@ if(not SECRET_KEY):
     logging.warning("WARNING - IMPORTANT: SECRET_KEY env var was not set, random secret key was used")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv('DEBUG', False)
+DEBUG = os.getenv('DEBUG', 'False')
 CRISPY_FAIL_SILENTLY = not DEBUG
 PROD_MODE = os.getenv('PROD_MODE', 'False')
 

--- a/birdspotter/birdspotter/settings.py
+++ b/birdspotter/birdspotter/settings.py
@@ -31,7 +31,7 @@ if(not SECRET_KEY):
     logging.warning("WARNING - IMPORTANT: SECRET_KEY env var was not set, random secret key was used")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv('DEBUG')
+DEBUG = os.getenv('DEBUG', False)
 CRISPY_FAIL_SILENTLY = not DEBUG
 PROD_MODE = os.getenv('PROD_MODE', 'False')
 

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   birdspotter:
-    image: devinchristianson/birdspotter:latest
+    image: birdspotter/birdspotter:latest
     env_file: 
       - .env
     environment:
@@ -55,7 +55,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
   nginx:
-    image: devinchristianson/birdspotter:nginx-upload
+    image: birdspotter/proxy-upload:v0.0.3
     depends_on:
       - birdspotter
     volumes:


### PR DESCRIPTION
This PR:
- migrates birdspotter to the new docker hub repo https://hub.docker.com/repository/docker/birdspotter/birdspotter
- migrates custom nginx proxy repo to https://hub.docker.com/repository/docker/birdspotter/proxy-upload